### PR TITLE
Clean up install.sh and add crates.io installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
 curl -fsSL https://raw.githubusercontent.com/yusukeshib/nixy/main/install.sh | bash
 ```
 
-This will try (in order): pre-built binary, cargo install, or nix build.
+This will try (in order): pre-built binary or nix build.
 
-**With cargo:**
+**With cargo (from crates.io):**
 
 ```bash
-cargo install --git https://github.com/yusukeshib/nixy.git
+cargo install nixy
 ```
 
 **With nix:**
@@ -221,10 +221,10 @@ my-overlay.url = "github:user/my-overlay";
 Any content outside these markers will be overwritten when nixy regenerates the flake. For heavy customization, see "Customizing flake.nix" in the Appendix.
 
 **How do I update nixy?**
-Rebuild from source or run `cargo install --git https://github.com/yusukeshib/nixy.git --force`.
+Run `cargo install nixy` to get the latest version from crates.io, or re-run the install script.
 
 **How do I uninstall nixy?**
-Delete the `nixy` binary (typically `/usr/local/bin/nixy` or `~/.cargo/bin/nixy`). Your flake.nix files remain and work with standard `nix` commands.
+Delete the `nixy` binary (typically `~/.local/bin/nixy` or `~/.cargo/bin/nixy`). Your flake.nix files remain and work with standard `nix` commands.
 
 **Why not use `nix profile` directly?**
 `nix profile` lacks built-in reproducibility - there's no official way to export your packages and recreate the same environment on another machine. nixy uses `flake.nix` as the source of truth, which can be copied, version-controlled, and shared.

--- a/README_ja.md
+++ b/README_ja.md
@@ -66,8 +66,22 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
 
 ### 2. nixy をインストール
 
+**クイックインストール（推奨）:**
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/yusukeshib/nixy/main/install.sh | bash
+```
+
+**cargo でインストール（crates.io から）:**
+
+```bash
+cargo install nixy
+```
+
+**nix でインストール:**
+
+```bash
+nix profile install github:yusukeshib/nixy
 ```
 
 ### 3. シェルを設定
@@ -192,7 +206,7 @@ my-overlay.url = "github:user/my-overlay";
 これらのマーカー外のコンテンツは、nixy が flake を再生成する際に上書きされます。詳細なカスタマイズについては、付録の「flake.nix のカスタマイズ」を参照してください。
 
 **nixy をアップデートするには？**
-`nixy self-upgrade` を実行します。更新を確認し、最新版をダウンロードして自動的に置き換えます。すでに最新版でも再インストールしたい場合は `--force` オプションを使用してください。
+`cargo install nixy` で crates.io から最新版を取得するか、インストールスクリプトを再実行してください。
 
 **nixy をアンインストールするには？**
 `nixy` スクリプトを削除するだけ。flake.nix ファイルはそのまま残り、標準の `nix` コマンドで使えます。


### PR DESCRIPTION
## Summary
- Remove cargo build from install.sh (keep pre-built binary + nix fallback)
- Add `cargo install nixy` (crates.io) as installation option in both READMEs
- Update FAQ about updating nixy to mention `cargo install nixy`
- Fix binary path in uninstall instructions (`~/.local/bin` instead of `/usr/local/bin`)

## Test plan
- [ ] Run `./install.sh` - should try pre-built binary then nix (no cargo)
- [ ] Verify `cargo install nixy` works from crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)