### PR TITLE
Improve documentation: reorganize commands and add aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,23 +131,51 @@ Packages are installed globally and available in all terminal sessions.
 
 ## Commands
 
+### Package Management
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `nixy install <pkg>` | `add` | Install a package from nixpkgs |
+| `nixy install --from <flake> <pkg>` | | Install from a flake (registry name or URL) |
+| `nixy install --file <path>` | | Install from a custom nix file |
+| `nixy uninstall <pkg>` | `remove` | Uninstall a package |
+| `nixy list` | `ls` | List packages in flake.nix |
+| `nixy search <query>` | | Search for packages |
+| `nixy upgrade [input...]` | | Upgrade all inputs or specific ones |
+| `nixy sync` | | Build environment from flake.nix (for new machines) |
+| `nixy gc` | | Clean up old package versions |
+
+### Profile Management
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `nixy profile` | | Show current profile |
+| `nixy profile switch <name>` | `use` | Switch to a different profile |
+| `nixy profile switch -c <name>` | | Create and switch to a new profile |
+| `nixy profile list` | `ls` | List all profiles |
+| `nixy profile delete <name>` | `rm` | Delete a profile (requires `--force`) |
+
+### Utilities
+
 | Command | Description |
 |---------|-------------|
-| `nixy install <pkg>` | Install a package from nixpkgs |
-| `nixy install --from <flake> <pkg>` | Install from a flake (registry name or URL) |
-| `nixy uninstall <pkg>` | Uninstall a package |
-| `nixy list` | List packages in flake.nix |
-| `nixy search <query>` | Search for packages |
-| `nixy upgrade [input...]` | Upgrade all inputs or specific ones |
-| `nixy sync` | Build environment from flake.nix (for new machines) |
-| `nixy gc` | Clean up old package versions |
 | `nixy config <shell>` | Output shell config (for PATH setup) |
 | `nixy version` | Show nixy version |
-| `nixy profile` | Show current profile |
-| `nixy profile switch <name>` | Switch to a different profile |
-| `nixy profile switch -c <name>` | Create and switch to a new profile |
-| `nixy profile list` | List all profiles |
-| `nixy profile delete <name>` | Delete a profile (requires `--force`) |
+| `nixy self-upgrade` | Upgrade nixy to the latest version |
+| `nixy self-upgrade --force` | Force reinstall even if already at latest |
+
+### Install Options
+
+The `install` command supports several options:
+
+```bash
+nixy install ripgrep              # Install from nixpkgs (default)
+nixy install --from <flake> <pkg> # Install from external flake
+nixy install --file my-pkg.nix    # Install from custom nix file
+nixy install --force <pkg>        # Force regeneration of flake.nix
+```
+
+Use `--force` when you've made manual edits outside the nixy markers and want to proceed anyway (your custom changes will be lost).
 
 ## Multiple Profiles
 
@@ -221,7 +249,7 @@ my-overlay.url = "github:user/my-overlay";
 Any content outside these markers will be overwritten when nixy regenerates the flake. For heavy customization, see "Customizing flake.nix" in the Appendix.
 
 **How do I update nixy?**
-Run `cargo install nixy` to get the latest version from crates.io, or re-run the install script.
+Run `nixy self-upgrade` to automatically update to the latest version. Alternatively, use `cargo install nixy` or re-run the install script.
 
 **How do I uninstall nixy?**
 Delete the `nixy` binary (typically `~/.local/bin/nixy` or `~/.cargo/bin/nixy`). Your flake.nix files remain and work with standard `nix` commands.

--- a/README_ja.md
+++ b/README_ja.md
@@ -115,24 +115,51 @@ nixy upgrade            # 全パッケージをアップグレード
 
 ## コマンド
 
+### パッケージ管理
+
+| コマンド | エイリアス | 説明 |
+|---------|-----------|------|
+| `nixy install <pkg>` | `add` | nixpkgs からパッケージをインストール |
+| `nixy install --from <flake> <pkg>` | | flake からインストール（レジストリ名または URL） |
+| `nixy install --file <path>` | | カスタム nix ファイルからインストール |
+| `nixy uninstall <pkg>` | `remove` | パッケージをアンインストール |
+| `nixy list` | `ls` | インストール済みパッケージを一覧表示 |
+| `nixy search <query>` | | パッケージを検索 |
+| `nixy upgrade [input...]` | | 全 input または指定した input をアップグレード |
+| `nixy sync` | | flake.nix から環境をビルド（新しいマシン用） |
+| `nixy gc` | | 古いパッケージを削除 |
+
+### プロファイル管理
+
+| コマンド | エイリアス | 説明 |
+|---------|-----------|------|
+| `nixy profile` | | 現在のプロファイルを表示 |
+| `nixy profile switch <name>` | `use` | プロファイルを切り替え |
+| `nixy profile switch -c <name>` | | 新しいプロファイルを作成して切り替え |
+| `nixy profile list` | `ls` | 全プロファイルを一覧表示 |
+| `nixy profile delete <name>` | `rm` | プロファイルを削除（`--force` 必須） |
+
+### ユーティリティ
+
 | コマンド | 説明 |
 |---------|------|
-| `nixy install <pkg>` | nixpkgs からパッケージをインストール |
-| `nixy install --from <flake> <pkg>` | flake からインストール（レジストリ名または URL） |
-| `nixy uninstall <pkg>` | パッケージをアンインストール |
-| `nixy list` | インストール済みパッケージを一覧表示 |
-| `nixy search <query>` | パッケージを検索 |
-| `nixy upgrade [input...]` | 全 input または指定した input をアップグレード |
-| `nixy sync` | flake.nix から環境をビルド（新しいマシン用） |
-| `nixy gc` | 古いパッケージを削除 |
 | `nixy config <shell>` | シェル設定を出力（PATH 設定用） |
 | `nixy version` | nixy のバージョンを表示 |
 | `nixy self-upgrade` | nixy を最新版にアップグレード |
-| `nixy profile` | 現在のプロファイルを表示 |
-| `nixy profile switch <name>` | プロファイルを切り替え |
-| `nixy profile switch -c <name>` | 新しいプロファイルを作成して切り替え |
-| `nixy profile list` | 全プロファイルを一覧表示 |
-| `nixy profile delete <name>` | プロファイルを削除（`--force` 必須） |
+| `nixy self-upgrade --force` | 最新版でも強制的に再インストール |
+
+### install オプション
+
+`install` コマンドはいくつかのオプションをサポートしています：
+
+```bash
+nixy install ripgrep              # nixpkgs からインストール（デフォルト）
+nixy install --from <flake> <pkg> # 外部 flake からインストール
+nixy install --file my-pkg.nix    # カスタム nix ファイルからインストール
+nixy install --force <pkg>        # flake.nix を強制的に再生成
+```
+
+`--force` は、nixy マーカー外を手動で編集した場合に使用します（カスタム変更は失われます）。
 
 ## 複数プロファイル
 
@@ -206,7 +233,7 @@ my-overlay.url = "github:user/my-overlay";
 これらのマーカー外のコンテンツは、nixy が flake を再生成する際に上書きされます。詳細なカスタマイズについては、付録の「flake.nix のカスタマイズ」を参照してください。
 
 **nixy をアップデートするには？**
-`cargo install nixy` で crates.io から最新版を取得するか、インストールスクリプトを再実行してください。
+`nixy self-upgrade` で自動的に最新版にアップデートできます。または `cargo install nixy` やインストールスクリプトの再実行でも可能です。
 
 **nixy をアンインストールするには？**
 `nixy` スクリプトを削除するだけ。flake.nix ファイルはそのまま残り、標準の `nix` コマンドで使えます。


### PR DESCRIPTION
## Summary
- Reorganize Commands section into 3 categories: Package Management, Profile Management, and Utilities
- Add command aliases (`add`, `remove`, `ls`, `use`, `rm`) to both English and Japanese README
- Add missing `self-upgrade` command to English README (was already in Japanese version)
- Add "Install Options" section explaining `--from`, `--file`, `--force` flags
- Update FAQ to recommend `nixy self-upgrade` for updating
- Add profile feature demo to demo.tape (create/switch/list profiles)
- Fix flake.nix path in demo.tape for new profile structure (`profiles/default/`)

## Test plan
- [ ] Review README.md formatting
- [ ] Review README_ja.md formatting
- [ ] Regenerate demo.gif with `vhs demo.tape` if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)