### PR TITLE
Add rollback FAQ to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,16 @@ Delete the `nixy` binary (typically `~/.local/bin/nixy` or `~/.cargo/bin/nixy`).
 **Why not use `nix profile` directly?**
 `nix profile` lacks built-in reproducibility - there's no official way to export your packages and recreate the same environment on another machine. nixy uses `flake.nix` as the source of truth, which can be copied, version-controlled, and shared.
 
+**How do I rollback to a previous state?**
+Since nixy is declarative, your `flake.nix` and `flake.lock` files *are* the state. If you version control them with git (recommended), rollback is simple:
+
+```bash
+git checkout HEAD~1 -- flake.nix flake.lock  # Revert to previous commit
+nixy sync                                     # Apply the old state
+```
+
+This is more powerful than `nix profile rollback` - you can go back to any point in history, see why changes were made via commit messages, and experiment with branches.
+
 ---
 
 ## Appendix

--- a/README_ja.md
+++ b/README_ja.md
@@ -241,6 +241,16 @@ my-overlay.url = "github:user/my-overlay";
 **なぜ `nix profile` を直接使わないの？**
 `nix profile` には再現性の仕組みがありません - パッケージをエクスポートして別のマシンで同じ環境を再現する公式の方法がないのです。nixy は `flake.nix` を真実の源として使うため、コピー、バージョン管理、共有が可能です。
 
+**以前の状態にロールバックするには？**
+nixy は宣言的なので、`flake.nix` と `flake.lock` が状態そのものです。git で管理していれば（推奨）、ロールバックは簡単：
+
+```bash
+git checkout HEAD~1 -- flake.nix flake.lock  # 前のコミットに戻す
+nixy sync                                     # 古い状態を適用
+```
+
+これは `nix profile rollback` より強力です - 履歴の任意の時点に戻れる、コミットメッセージで変更理由がわかる、ブランチで実験できる、といった利点があります。
+
 ---
 
 ## 付録


### PR DESCRIPTION
## Summary
- Add FAQ entry explaining how to rollback to a previous state using git
- Document the declarative approach: `git checkout` + `nixy sync`
- Explain advantages over `nix profile rollback` (arbitrary history, commit messages, branches)

## Test plan
- [ ] Verify FAQ renders correctly in both README.md and README_ja.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)