### PR TITLE
Use rnix AST parsing for is_flake_file

### DIFF
--- a/src/flake/mod.rs
+++ b/src/flake/mod.rs
@@ -52,25 +52,8 @@ pub fn is_flake_file(path: &Path) -> bool {
                 }
                 Some(rnix::ast::Attr::Str(s)) => {
                     // Handle quoted attribute names like { "inputs" = ...; }
-                    // Extract the string value, returning None if it contains interpolation
-                    let mut result = String::new();
-                    let mut has_interpolation = false;
-                    for part in s.parts() {
-                        match part {
-                            rnix::ast::InterpolPart::Literal(lit) => {
-                                result.push_str(&lit.to_string());
-                            }
-                            rnix::ast::InterpolPart::Interpolation(_) => {
-                                // Can't evaluate dynamic attribute names, skip this attribute
-                                has_interpolation = true;
-                            }
-                        }
-                    }
-                    if has_interpolation {
-                        None
-                    } else {
-                        Some(result)
-                    }
+                    // Reuse shared helper; returns None if it contains interpolation
+                    parser::extract_string_value(&s)
                 }
                 _ => None,
             };

--- a/src/flake/parser.rs
+++ b/src/flake/parser.rs
@@ -93,8 +93,10 @@ fn extract_expr_value(expr: &rnix::ast::Expr) -> Option<String> {
     }
 }
 
-/// Extract the string value from a Str node, handling escape sequences
-fn extract_string_value(s: &rnix::ast::Str) -> Option<String> {
+/// Extract the string value from a Str node, handling escape sequences.
+///
+/// Returns None if the string contains interpolation (cannot be evaluated statically).
+pub fn extract_string_value(s: &rnix::ast::Str) -> Option<String> {
     let mut result = String::new();
     for part in s.parts() {
         match part {


### PR DESCRIPTION
## Summary
- Replace naive string matching with rnix AST parsing for detecting flake files
- Fixes false positives (e.g., comments containing `inputs = `) and false negatives (unusual formatting)
- Adds 7 unit tests for comprehensive coverage

## Test plan
- [x] Run `cargo test` - all 138 tests pass
- [x] Run `cargo clippy` - no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)