### PR TITLE
Fix symlink handling for flake.nix inside local packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nixy-rs"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version = "1.80"
 description = "Homebrew-style wrapper for Nix using flake.nix"


### PR DESCRIPTION
## Summary
- Fix upgrade command failing when a local flake package contains a symlinked `flake.nix` file
- When `flake.nix` is a symlink, resolve it to find the actual directory containing the target file
- Add test case for symlinked `flake.nix` scenario

## Problem
PR #50 fixed the case where the **package directory** is a symlink. This PR fixes the case where the **flake.nix file** inside the directory is a symlink:

```
gke-gcloud-auth-plugin/
└── flake.nix -> /Users/yusuke/env/.config/nixy/packages/gke-gcloud-auth-plugin/flake.nix
```

When Nix copies this to the store, it can't follow the absolute symlink, causing:
```
error: path '/nix/store/xxx/Users/yusuke/env/.config/nixy/packages/.../flake.nix' does not exist
```

## Test plan
- [x] Run `cargo test` - all 212 tests pass
- [ ] Test manually with a local flake containing symlinked `flake.nix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)