### PR TITLE
Add dev to extraOutputsToInstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "nixy-rs"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nixy-rs"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.80"
 description = "Homebrew-style wrapper for Nix using flake.nix"

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -262,10 +262,7 @@ fn validate_and_resolve_flake_package(
     // Fallback: if source_name is "default" and pkg is different, try pkg as the attribute
     let tried_fallback = source_name == "default" && pkg != "default";
     if tried_fallback {
-        info(&format!(
-            "Package 'default' not found, trying '{}'...",
-            pkg
-        ));
+        info(&format!("Package 'default' not found, trying '{}'...", pkg));
         if let Some(pkg_output) = Nix::validate_flake_package(flake_url, pkg)? {
             return Ok((pkg.to_string(), pkg_output));
         }

--- a/src/flake/template.rs
+++ b/src/flake/template.rs
@@ -347,7 +347,7 @@ impl FlakeBuilder {
           default = pkgs.buildEnv {{
             name = "nixy-env";
             {paths_section}
-            extraOutputsToInstall = [ "man" "doc" "info" ];
+            extraOutputsToInstall = [ "man" "doc" "info" "dev" ];
           }};
         }});
     }};
@@ -647,7 +647,7 @@ mod tests {
     fn test_buildenv_has_extra_outputs() {
         let state = PackageState::default();
         let flake = generate_flake(&state, None);
-        assert!(flake.contains("extraOutputsToInstall = [ \"man\" \"doc\" \"info\" ]"));
+        assert!(flake.contains("extraOutputsToInstall = [ \"man\" \"doc\" \"info\" \"dev\" ]"));
     }
 
     #[test]
@@ -743,7 +743,7 @@ mod tests {
         // Empty flake should have buildEnv structure with empty paths
         assert!(flake.contains("default = pkgs.buildEnv"));
         assert!(flake.contains("paths = ["));
-        assert!(flake.contains("extraOutputsToInstall = [ \"man\" \"doc\" \"info\" ]"));
+        assert!(flake.contains("extraOutputsToInstall = [ \"man\" \"doc\" \"info\" \"dev\" ]"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `"dev"` to `extraOutputsToInstall` in the flake template so dev outputs (headers, pkg-config files, etc.) are installed automatically
- Fixes issues like `ffmpeg-dev` not being available
- Bump to 0.3.2

## Test plan
- [x] `cargo test` — all 66 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)