### PR TITLE
Add --accept-flake-config to NIX_FLAGS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "nixy-rs"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nixy-rs"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.80"
 description = "Homebrew-style wrapper for Nix using flake.nix"

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ No, it's regenerated from `nixy.json` on every operation. Use flake references f
 **How does nixy differ from nix profile?**
 nixy adds reproducibility on top of Nix - your `nixy.json` + `flake.lock` can be synced and version controlled across machines.
 
+**Does nixy honor flake-declared binary caches (e.g. Cachix)?**
+Yes. nixy passes `--accept-flake-config` to every `nix` invocation, so a custom flake's `nixConfig.extra-substituters` / `extra-trusted-public-keys` are honored automatically. This lets `nixy install <flake-ref>` pull prebuilt artifacts from project-provided caches instead of rebuilding locally.
+
 **How do I rollback?**
 Version control your `nixy.json` and `flake.lock` with git:
 ```bash

--- a/README_ja.md
+++ b/README_ja.md
@@ -173,6 +173,9 @@ nixy は**純粋に宣言的** - `nixy.json` が真実の源であり、`flake.n
 **nix profile との違いは？**
 nixy は Nix の上に再現性を追加します。`nixy.json` + `flake.lock` を複数マシン間で同期・バージョン管理できます。
 
+**flake が宣言したバイナリキャッシュ（Cachix など）は使われる？**
+はい。nixy はすべての `nix` 呼び出しに `--accept-flake-config` を渡すので、カスタム flake の `nixConfig.extra-substituters` / `extra-trusted-public-keys` は自動で適用されます。これにより `nixy install <flake-ref>` でプロジェクト提供のキャッシュから事前ビルド済み成果物を取得でき、ローカルでの再ビルドを避けられます。
+
 **ロールバックするには？**
 `nixy.json` と `flake.lock` を git で管理してください：
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         nixy = pkgs.rustPlatform.buildRustPackage {
           pname = "nixy";
-          version = "0.3.2";
+          version = "0.3.3";
 
           src = ./.;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,12 +100,21 @@ impl Default for Config {
 /// Default profile name
 pub const DEFAULT_PROFILE: &str = "default";
 
-/// Nix experimental features flags
+/// Flags passed to every `nix` invocation.
+///
+/// - `--extra-experimental-features nix-command flakes`: nixy relies on flakes.
+/// - `--accept-flake-config`: honor `nixConfig` (e.g. extra substituters /
+///   trusted public keys) declared inside custom flake inputs. Users opt into
+///   third-party flakes explicitly via `nixy install <flake-ref>`, so trusting
+///   their `nixConfig` is consistent with that opt-in and lets prebuilt
+///   binaries from project-provided binary caches (e.g. Cachix) be substituted
+///   instead of rebuilt locally.
 pub const NIX_FLAGS: &[&str] = &[
     "--extra-experimental-features",
     "nix-command",
     "--extra-experimental-features",
     "flakes",
+    "--accept-flake-config",
 ];
 
 #[cfg(test)]
@@ -113,6 +122,17 @@ mod tests {
     use super::*;
     use std::env;
     use std::sync::{Mutex, MutexGuard};
+
+    #[test]
+    fn nix_flags_enable_flakes_and_accept_flake_config() {
+        assert!(NIX_FLAGS.contains(&"flakes"));
+        assert!(NIX_FLAGS.contains(&"nix-command"));
+        assert!(
+            NIX_FLAGS.contains(&"--accept-flake-config"),
+            "NIX_FLAGS must include --accept-flake-config so that nixConfig \
+             declared in custom flake inputs (e.g. extra substituters) is honored"
+        );
+    }
 
     // Mutex to serialize tests that modify environment variables
     static ENV_MUTEX: Mutex<()> = Mutex::new(());


### PR DESCRIPTION
## Summary

When a custom flake input declares `nixConfig.extra-substituters` / `extra-trusted-public-keys` (e.g. `pi.cachix.org` for [pi.nix](https://github.com/lukasl-dev/pi.nix)), nixy previously ignored them: nix only honors them with explicit `--accept-flake-config` or an interactive prompt. nixy runs nix non-interactively so the prompt never appears, and installs fall back to local builds — which then fail or take forever for packages the project intentionally ships via a binary cache.

Adding `--accept-flake-config` to `NIX_FLAGS` lets nixy substitute prebuilt binaries from project-provided binary caches automatically. Users already opt into third-party flakes explicitly via `nixy install <flake-ref>`, so trusting their `nixConfig` is consistent with that opt-in.

## Changes

- `src/config.rs`: append `--accept-flake-config` to `NIX_FLAGS`, with doc-comment justifying the choice.
- Unit test asserting all three flags are present.
- `README.md` / `README_ja.md`: FAQ entry explaining the behavior.
- `Cargo.toml` / `flake.nix`: bump to 0.3.3.

## Test plan

- [x] `cargo test` (138 + 66 tests pass)
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean

## Motivation

Tried installing [`github:lukasl-dev/pi.nix`](https://github.com/lukasl-dev/pi.nix) (which publishes prebuilt artifacts to `pi.cachix.org`) via `nixy install`. Without `--accept-flake-config`, the substituter is ignored and nixy attempts a full local source build — which currently fails due to upstream-tarball issues. With this change, the install completes by pulling from Cachix.