### PR TITLE
Improve shell completions for 'nixy config zsh/bash'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "nixy-rs"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nixy-rs"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.80"
 description = "Homebrew-style wrapper for Nix using flake.nix"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ For fish (`~/.config/fish/config.fish`):
 nixy config fish | source
 ```
 
+For bash (`~/.bashrc`):
+
+```bash
+eval "$(nixy config bash)"
+```
+
+For zsh and bash this also installs tab completion: subcommands, flags, and
+dynamic completion of installed package names (`nixy uninstall <Tab>`,
+`nixy update <Tab>`, `nixy file <Tab>`) and profile names
+(`nixy profile <Tab>`). Make sure `compinit` has run in your `.zshrc` before
+the `eval` line.
+
 ### 3. Start using
 
 ```bash

--- a/README_ja.md
+++ b/README_ja.md
@@ -51,6 +51,17 @@ fish の場合（`~/.config/fish/config.fish`）：
 nixy config fish | source
 ```
 
+bash の場合（`~/.bashrc`）：
+
+```bash
+eval "$(nixy config bash)"
+```
+
+zsh と bash では、これによりタブ補完も有効になります。サブコマンドやフラグに加え、
+インストール済みパッケージ名（`nixy uninstall <Tab>`、`nixy update <Tab>`、
+`nixy file <Tab>`）やプロファイル名（`nixy profile <Tab>`）が動的に補完されます。
+`.zshrc` 内で `eval` 行より前に `compinit` を実行しておいてください。
+
 ### 3. 使い始める
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,6 +52,10 @@ pub enum Commands {
 
     /// Show path to package source file in Nix store
     File(FileArgs),
+
+    /// Print dynamic completion candidates (used by shell completions)
+    #[command(hide = true)]
+    Completions(CompletionsArgs),
 }
 
 #[derive(Args)]
@@ -109,4 +113,10 @@ pub struct UpgradeArgs {
 pub struct FileArgs {
     /// Package name
     pub package: String,
+}
+
+#[derive(Args)]
+pub struct CompletionsArgs {
+    /// What to complete (e.g. installed, profiles)
+    pub kind: String,
 }

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -1,0 +1,71 @@
+//! Dynamic completion helper.
+//!
+//! Prints newline-separated completion candidates consumed by the shell
+//! completion scripts (`src/completions/nixy.zsh`, `nixy.bash`). This keeps the
+//! candidate lists (installed packages, profiles) always in sync with the real
+//! config instead of being hard-coded in the shell scripts.
+//!
+//! All lookups swallow errors and fall back to an empty list: completion must
+//! never fail or print diagnostics, even when the config is missing or invalid.
+
+use crate::config::Config;
+use crate::error::Result;
+use crate::flake::parser::collect_local_packages;
+use crate::nixy_config::{nixy_json_exists, NixyConfig};
+use crate::profile::get_flake_dir;
+use crate::state::{get_state_path, PackageState};
+
+pub fn run(config: &Config, kind: &str) -> Result<()> {
+    let candidates = match kind {
+        "installed" => installed_package_names(config),
+        "profiles" => profile_names(config),
+        // Unknown kinds print nothing so future shell scripts degrade gracefully.
+        _ => Vec::new(),
+    };
+
+    for name in candidates {
+        println!("{}", name);
+    }
+
+    Ok(())
+}
+
+/// Names of all installed packages in the active profile (or legacy state).
+fn installed_package_names(config: &Config) -> Vec<String> {
+    let mut names = Vec::new();
+
+    if nixy_json_exists(config) {
+        if let Ok(nixy_config) = NixyConfig::load(config) {
+            if let Some(profile) = nixy_config.get_active_profile() {
+                names.extend(profile.packages.iter().cloned());
+                names.extend(profile.resolved_packages.iter().map(|p| p.name.clone()));
+                names.extend(profile.custom_packages.iter().map(|p| p.name.clone()));
+            }
+        }
+
+        // Local packages from the global packages/ directory.
+        if config.global_packages_dir.exists() {
+            let (local_packages, local_flakes) =
+                collect_local_packages(&config.global_packages_dir);
+            names.extend(local_packages.into_iter().map(|p| p.name));
+            names.extend(local_flakes.into_iter().map(|f| f.name));
+        }
+    } else if let Ok(flake_dir) = get_flake_dir(config) {
+        if let Ok(state) = PackageState::load(&get_state_path(&flake_dir)) {
+            names.extend(state.packages.iter().cloned());
+            names.extend(state.resolved_packages.iter().map(|p| p.name.clone()));
+            names.extend(state.custom_packages.iter().map(|p| p.name.clone()));
+        }
+    }
+
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Names of all configured profiles.
+fn profile_names(config: &Config) -> Vec<String> {
+    NixyConfig::load(config)
+        .map(|c| c.list_profiles())
+        .unwrap_or_default()
+}

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,12 +1,21 @@
 use crate::error::{Error, Result};
 
+/// POSIX PATH export shared by bash/zsh/sh.
+const POSIX_PATH: &str = r#"# nixy shell configuration
+export PATH="$HOME/.local/state/nixy/env/bin:$PATH""#;
+
 pub fn run(shell: &str) -> Result<()> {
     match shell {
-        "bash" | "zsh" | "sh" => {
-            println!(
-                r#"# nixy shell configuration
-export PATH="$HOME/.local/state/nixy/env/bin:$PATH""#
-            );
+        "zsh" => {
+            println!("{}", POSIX_PATH);
+            print!("{}", include_str!("../completions/nixy.zsh"));
+        }
+        "bash" => {
+            println!("{}", POSIX_PATH);
+            print!("{}", include_str!("../completions/nixy.bash"));
+        }
+        "sh" => {
+            println!("{}", POSIX_PATH);
         }
         "fish" => {
             println!(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod completions;
 pub mod config;
 pub mod file;
 pub mod install;

--- a/src/completions/nixy.bash
+++ b/src/completions/nixy.bash
@@ -1,0 +1,46 @@
+# nixy bash completion
+# Dynamic completion candidates are produced by the hidden `nixy completions`
+# helper, so installed package names and profiles always stay in sync.
+
+_nixy() {
+    local cur prev cmd
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    local subcommands="install add uninstall remove list ls search update sync config profile upgrade file"
+
+    if [[ $COMP_CWORD -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
+        return
+    fi
+
+    cmd="${COMP_WORDS[1]}"
+    case "$cmd" in
+        uninstall|remove|file)
+            COMPREPLY=( $(compgen -W "$(command nixy completions installed 2>/dev/null)" -- "$cur") )
+            ;;
+        update)
+            COMPREPLY=( $(compgen -W "--all $(command nixy completions installed 2>/dev/null)" -- "$cur") )
+            ;;
+        install|add)
+            if [[ "$cur" == -* || "$prev" == "-p" || "$prev" == "--platform" ]]; then
+                COMPREPLY=( $(compgen -W "-p --platform darwin macos linux x86_64-darwin aarch64-darwin x86_64-linux aarch64-linux" -- "$cur") )
+            fi
+            ;;
+        config)
+            COMPREPLY=( $(compgen -W "zsh bash fish" -- "$cur") )
+            ;;
+        profile)
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=( $(compgen -W "-c -d" -- "$cur") )
+            else
+                COMPREPLY=( $(compgen -W "$(command nixy completions profiles 2>/dev/null)" -- "$cur") )
+            fi
+            ;;
+        upgrade)
+            COMPREPLY=( $(compgen -W "-f --force" -- "$cur") )
+            ;;
+    esac
+}
+
+complete -F _nixy nixy

--- a/src/completions/nixy.zsh
+++ b/src/completions/nixy.zsh
@@ -1,0 +1,97 @@
+# nixy zsh completion
+# Dynamic completion candidates are produced by the hidden `nixy completions`
+# helper, so installed package names and profiles always stay in sync.
+
+__nixy_installed() {
+    local -a pkgs
+    pkgs=(${(f)"$(command nixy completions installed 2>/dev/null)"})
+    if (( ${#pkgs} )); then
+        _describe 'package' pkgs
+    fi
+}
+
+__nixy_profiles() {
+    local -a profiles
+    profiles=(${(f)"$(command nixy completions profiles 2>/dev/null)"})
+    if (( ${#profiles} )); then
+        _describe 'profile' profiles
+    fi
+}
+
+_nixy() {
+    local curcontext="$curcontext" state line
+    typeset -A opt_args
+
+    _arguments -C \
+        '1: :->subcmd' \
+        '*:: :->args'
+
+    case $state in
+        subcmd)
+            local -a subcmds
+            subcmds=(
+                'install:Install a package from nixpkgs'
+                'add:Install a package from nixpkgs (alias)'
+                'uninstall:Uninstall a package'
+                'remove:Uninstall a package (alias)'
+                'list:List installed packages'
+                'ls:List installed packages (alias)'
+                'search:Search for packages'
+                'update:Update packages and flake inputs'
+                'sync:Build environment and create symlink'
+                'config:Output shell configuration'
+                'profile:Profile management'
+                'upgrade:Upgrade nixy to the latest version'
+                'file:Show path to a package source file'
+            )
+            _describe 'subcommand' subcmds
+            ;;
+        args)
+            case $words[1] in
+                install|add)
+                    _arguments \
+                        '*'{-p,--platform}'=[Restrict to platform(s)]:platform:(darwin macos linux x86_64-darwin aarch64-darwin x86_64-linux aarch64-linux)' \
+                        '1:package:'
+                    ;;
+                uninstall|remove)
+                    _arguments '1:package:__nixy_installed'
+                    ;;
+                update)
+                    _arguments \
+                        '--all[Update all packages and inputs]' \
+                        '*:package:__nixy_installed'
+                    ;;
+                file)
+                    _arguments '1:package:__nixy_installed'
+                    ;;
+                search)
+                    _arguments '1:query:'
+                    ;;
+                config)
+                    if (( CURRENT == 2 )); then
+                        local -a shells
+                        shells=(
+                            'zsh:Zsh configuration'
+                            'bash:Bash configuration'
+                            'fish:Fish configuration'
+                        )
+                        _describe 'shell' shells
+                    fi
+                    ;;
+                profile)
+                    _arguments \
+                        '-c[Create the profile if it does not exist]' \
+                        '-d[Delete the specified profile]' \
+                        '1:profile:__nixy_profiles'
+                    ;;
+                upgrade)
+                    _arguments '(-f --force)'{-f,--force}'[Force reinstall even if already latest]'
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+if typeset -f compdef >/dev/null; then
+    compdef _nixy nixy
+fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,20 +22,29 @@ fn main() {
     // Initialize signal handler for Ctrl+C rollback
     rollback::init_signal_handler();
 
+    let cli = Cli::parse();
+
+    // Meta commands don't touch the Nix store or config state. Skip the nix
+    // dependency check so they stay fast (e.g. shell completions run the binary
+    // on every <Tab>) and usable even when nix isn't installed.
+    let is_meta = matches!(
+        &cli.command,
+        Commands::Config { .. } | Commands::Completions(_)
+    );
+
     // Check dependencies
-    if let Err(e) = Nix::check_installed() {
-        commands::error(&e.to_string());
-        std::process::exit(1);
+    if !is_meta {
+        if let Err(e) = Nix::check_installed() {
+            commands::error(&e.to_string());
+            std::process::exit(1);
+        }
     }
 
-    let cli = Cli::parse();
     let config = Config::new();
 
     // Commands that don't need config state (skip migration)
-    let skip_migration = matches!(
-        &cli.command,
-        Commands::Config { .. } | Commands::Search { .. } | Commands::Upgrade(_)
-    );
+    let skip_migration =
+        is_meta || matches!(&cli.command, Commands::Search { .. } | Commands::Upgrade(_));
 
     // Auto-migrate from legacy format if needed
     if !skip_migration {
@@ -56,6 +65,7 @@ fn main() {
         Commands::Profile(args) => commands::profile::run(&config, args),
         Commands::Upgrade(args) => commands::upgrade::run(args.force),
         Commands::File(args) => commands::file::run(&config, args),
+        Commands::Completions(args) => commands::completions::run(&config, &args.kind),
     };
 
     if let Err(e) = result {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -81,6 +81,12 @@ fn test_config_bash() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("export PATH"));
     assert!(stdout.contains(".local/state/nixy/env/bin"));
+    // Embeds the bash completion script
+    assert!(
+        stdout.contains("complete -F _nixy nixy"),
+        "bash config should include completion: {}",
+        stdout
+    );
 }
 
 #[test]
@@ -89,6 +95,12 @@ fn test_config_zsh() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("export PATH"));
+    // Embeds the zsh completion script with dynamic helpers
+    assert!(
+        stdout.contains("compdef _nixy nixy") && stdout.contains("__nixy_installed"),
+        "zsh config should include completion: {}",
+        stdout
+    );
 }
 
 #[test]
@@ -112,6 +124,114 @@ fn test_config_invalid_shell() {
 fn test_config_no_shell() {
     let output = nixy_cmd().arg("config").output().unwrap();
     assert!(!output.status.success());
+}
+
+// =============================================================================
+// Completions helper tests (used by shell completion scripts)
+// =============================================================================
+
+fn write_nixy_json(env: &TestEnv, body: &str) {
+    std::fs::create_dir_all(&env.config_dir).unwrap();
+    std::fs::write(env.config_dir.join("nixy.json"), body).unwrap();
+}
+
+#[test]
+fn test_completions_installed_lists_all_package_kinds() {
+    let env = TestEnv::new();
+    write_nixy_json(
+        &env,
+        r#"{
+  "version": 3,
+  "active_profile": "default",
+  "profiles": {
+    "default": {
+      "packages": ["hello"],
+      "resolved_packages": [
+        {
+          "name": "ripgrep",
+          "version_spec": null,
+          "resolved_version": "14.0.0",
+          "attribute_path": "ripgrep",
+          "commit_hash": "abc1234"
+        }
+      ],
+      "custom_packages": [
+        {
+          "name": "pi-nix",
+          "input_name": "github-lukasl-dev-pi-nix",
+          "input_url": "github:lukasl-dev/pi.nix",
+          "package_output": "packages",
+          "source_name": null
+        }
+      ]
+    }
+  }
+}"#,
+    );
+
+    let output = env
+        .cmd()
+        .args(["completions", "installed"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let names: Vec<&str> = stdout.lines().collect();
+
+    assert!(names.contains(&"hello"), "legacy package: {}", stdout);
+    assert!(names.contains(&"ripgrep"), "resolved package: {}", stdout);
+    assert!(names.contains(&"pi-nix"), "custom package: {}", stdout);
+    // Output is sorted and deduplicated
+    let mut sorted = names.clone();
+    sorted.sort_unstable();
+    assert_eq!(names, sorted, "names should be sorted: {}", stdout);
+}
+
+#[test]
+fn test_completions_profiles_lists_profile_names() {
+    let env = TestEnv::new();
+    write_nixy_json(
+        &env,
+        r#"{
+  "version": 3,
+  "active_profile": "default",
+  "profiles": {
+    "default": { "packages": [], "resolved_packages": [], "custom_packages": [] },
+    "work": { "packages": [], "resolved_packages": [], "custom_packages": [] }
+  }
+}"#,
+    );
+
+    let output = env
+        .cmd()
+        .args(["completions", "profiles"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let names: Vec<&str> = stdout.lines().collect();
+    assert!(names.contains(&"default"));
+    assert!(names.contains(&"work"));
+}
+
+#[test]
+fn test_completions_unknown_kind_is_empty_and_succeeds() {
+    let env = TestEnv::new();
+    let output = env.cmd().args(["completions", "bogus"]).output().unwrap();
+    assert!(output.status.success(), "unknown kind should not fail");
+    assert!(output.stdout.is_empty(), "unknown kind prints nothing");
+}
+
+#[test]
+fn test_completions_installed_empty_config_succeeds() {
+    let env = TestEnv::new();
+    // No nixy.json and no flake: must still succeed with empty output.
+    let output = env
+        .cmd()
+        .args(["completions", "installed"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
Brings `nixy config zsh` / `nixy config bash` up to par with [box](https://github.com/yusukeshib/box): in addition to the `PATH` export, they now emit a real completion script.

What you get after `eval "$(nixy config zsh)"` (or `bash`):
- Subcommand completion (incl. aliases `add`/`remove`/`ls`) with descriptions
- Per-subcommand flag completion (`--all`, `-p/--platform` values, `-c`/`-d`, `-f/--force`, shells for `config`)
- **Dynamic** completion of installed package names for `uninstall`, `update`, and `file`
- **Dynamic** completion of profile names for `profile`

### How it works
- New embedded scripts `src/completions/nixy.zsh` and `nixy.bash` (via `include_str!`).
- A new hidden helper `nixy completions <kind>` (`installed`, `profiles`) prints newline-separated candidates from the active profile/legacy state, so the lists always match the real config instead of being hard-coded. It swallows all errors (never fails or prints diagnostics during completion).
- Meta commands (`config`, `completions`) now skip the nix dependency check and config migration, keeping completion fast on every `<Tab>` and usable even without nix installed.
- `fish` / `sh` behavior unchanged (PATH only).

## Test plan
- [x] `cargo fmt` / `cargo clippy` clean
- [x] `cargo test` — 138 + 72 pass (4 new integration tests)
  - `config zsh`/`bash` embed the completion script
  - `completions installed` lists legacy + resolved + custom packages, sorted & deduped
  - `completions profiles` lists profile names
  - unknown kind / empty config → succeeds with no output
- [x] `zsh -n` / `bash -n` syntax-check both scripts
- [x] Manual: `nixy uninstall <Tab>` resolves real package names (incl. `pi-nix`)
- [x] README / README_ja updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)