### PR TITLE
fix: re-lock local path: inputs before building (NAR hash mismatch)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "nixy-rs"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nixy-rs"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.80"
 description = "Homebrew-style wrapper for Nix using flake.nix"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         nixy = pkgs.rustPlatform.buildRustPackage {
           pname = "nixy";
-          version = "0.4.2";
+          version = "0.4.3";
 
           src = ./.;
 

--- a/src/commands/profile.rs
+++ b/src/commands/profile.rs
@@ -6,7 +6,7 @@ use dialoguer::{Confirm, Select};
 use crate::cli::ProfileArgs;
 use crate::config::{Config, DEFAULT_PROFILE};
 use crate::error::{Error, Result};
-use crate::flake::template::regenerate_flake_from_profile;
+use crate::flake::template::{local_path_input_names, regenerate_flake_from_profile};
 use crate::nix::Nix;
 use crate::nixy_config::{nixy_json_exists, NixyConfig, ProfileConfig};
 use crate::profile::{
@@ -165,6 +165,21 @@ fn switch(config: &Config, name: &str, create: bool) -> Result<()> {
 
         // Use get_flake_dir to resolve symlinks consistently with sync/upgrade
         let flake_dir = get_flake_dir(config)?;
+
+        // Re-lock local `path:` inputs before building. Their flake.lock
+        // entries pin a content hash (narHash), so any change to a local
+        // package directory makes the existing lock stale and `nix build`
+        // fails with a "NAR hash mismatch" error.
+        if flake_dir.join("flake.lock").exists() {
+            let local_inputs = local_path_input_names(&config.global_packages_dir);
+            if !local_inputs.is_empty() {
+                info("Refreshing local package inputs...");
+                if let Err(e) = Nix::flake_update(&flake_dir, &local_inputs) {
+                    warn(&format!("Failed to refresh local package inputs: {}", e));
+                }
+            }
+        }
+
         match Nix::build(&flake_dir, "default", &config.env_link) {
             Ok(_) => success(&format!("Switched to profile '{}'", name)),
             Err(e) => {

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -2,17 +2,27 @@ use std::fs;
 
 use crate::config::Config;
 use crate::error::{Error, Result};
-use crate::flake::template::{regenerate_flake, regenerate_flake_from_profile};
+use crate::flake::template::{
+    local_path_input_names, regenerate_flake, regenerate_flake_from_profile,
+};
 use crate::nix::Nix;
 use crate::nixy_config::{nixy_json_exists, NixyConfig};
 use crate::profile::get_flake_dir;
 use crate::state::{get_state_path, PackageState};
 
-use super::{info, success};
+use super::{info, success, warn};
 
 pub fn run(config: &Config) -> Result<()> {
     let flake_dir = get_flake_dir(config)?;
     let flake_path = flake_dir.join("flake.nix");
+
+    // Packages directory used for local packages: the global one for the
+    // nixy.json format, the flake-local one for legacy state.
+    let packages_dir = if nixy_json_exists(config) {
+        config.global_packages_dir.clone()
+    } else {
+        flake_dir.join("packages")
+    };
 
     // When using nixy.json, always regenerate flake.nix to ensure it reflects
     // the current state (nixy.json is the source of truth)
@@ -38,6 +48,22 @@ pub fn run(config: &Config) -> Result<()> {
         "Syncing packages with {}...",
         flake_path.display()
     ));
+
+    // Re-lock local `path:` inputs before building. Their flake.lock entries
+    // pin a content hash (narHash), so any change to a local package
+    // directory makes the existing lock stale and `nix build` fails with a
+    // "NAR hash mismatch" error.
+    if flake_dir.join("flake.lock").exists() {
+        let local_inputs = local_path_input_names(&packages_dir);
+        if !local_inputs.is_empty() {
+            info("Refreshing local package inputs...");
+            if let Err(e) = Nix::flake_update(&flake_dir, &local_inputs) {
+                // Not fatal on its own: the build below will surface the real
+                // error if the lock is actually broken.
+                warn(&format!("Failed to refresh local package inputs: {}", e));
+            }
+        }
+    }
 
     // Build environment and create symlink
     info("Building nixy environment...");

--- a/src/flake/template.rs
+++ b/src/flake/template.rs
@@ -528,6 +528,33 @@ fn collect_local_packages_with_paths(packages_dir: &Path) -> (Vec<LocalPackage>,
     collect_local_packages(packages_dir)
 }
 
+/// Collect the flake input names that are backed by local `path:` URLs.
+///
+/// These inputs are pinned by content hash (`narHash`) in `flake.lock`, so
+/// any edit to the local package directory makes the existing lock entry
+/// stale and `nix build` fails with a "NAR hash mismatch" error. Callers
+/// should re-lock these inputs (via `nix flake update <input>...`) before
+/// building.
+pub fn local_path_input_names(packages_dir: &Path) -> Vec<String> {
+    let (local_packages, local_flakes) = collect_local_packages(packages_dir);
+
+    // Local flake directories (packages/<name>/flake.nix) are always added
+    // as `path:` inputs named after the directory.
+    let mut names: Vec<String> = local_flakes.into_iter().map(|f| f.name).collect();
+
+    // Local .nix packages may declare their own input; only `path:` URLs are
+    // content-hash locked.
+    for pkg in &local_packages {
+        if let (Some(input_name), Some(input_url)) = (&pkg.input_name, &pkg.input_url) {
+            if input_url.starts_with("path:") && !names.contains(input_name) {
+                names.push(input_name.clone());
+            }
+        }
+    }
+
+    names
+}
+
 /// Regenerate flake.nix from state (legacy format)
 pub fn regenerate_flake(flake_dir: &Path, state: &PackageState) -> Result<()> {
     let flake_path = flake_dir.join("flake.nix");
@@ -1210,6 +1237,55 @@ mod tests {
             expected_path,
             builder.inputs
         );
+    }
+
+    #[test]
+    fn test_local_path_input_names() {
+        use tempfile::tempdir;
+
+        let temp = tempdir().unwrap();
+        let packages_dir = temp.path().join("packages");
+
+        // Missing packages dir -> no inputs
+        assert!(local_path_input_names(&packages_dir).is_empty());
+
+        // Local flake directory -> always a path: input named after the dir
+        fs::create_dir_all(packages_dir.join("my-flake")).unwrap();
+        fs::write(packages_dir.join("my-flake").join("flake.nix"), "{ }").unwrap();
+
+        // Local .nix package with a non-path input -> excluded
+        fs::write(
+            packages_dir.join("gh-pkg.nix"),
+            r#"
+{
+  pname = "gh-pkg";
+  inputs = {
+    gh-input.url = "github:user/repo";
+  };
+}
+"#,
+        )
+        .unwrap();
+
+        // Local .nix package with a path: input -> included
+        fs::write(
+            packages_dir.join("path-pkg.nix"),
+            r#"
+{
+  pname = "path-pkg";
+  inputs = {
+    path-input.url = "path:/some/where";
+  };
+}
+"#,
+        )
+        .unwrap();
+
+        let names = local_path_input_names(&packages_dir);
+        assert!(names.contains(&"my-flake".to_string()));
+        assert!(names.contains(&"path-input".to_string()));
+        assert!(!names.contains(&"gh-input".to_string()));
+        assert_eq!(names.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`nixy sync` fails with a NAR hash mismatch whenever a local package directory under `packages/` changes after it was first locked:

```
error: NAR hash mismatch in input 'path:/Users/.../.config/nixy/packages/gke-gcloud-auth-plugin?narHash=sha256-...', expected 'sha256-...' but got 'sha256-...'
```

The profile's `flake.lock` pins local `path:` inputs by content hash (`narHash`). `nixy sync` regenerates `flake.nix` but never refreshes the lock, so any edit to a local package (e.g. its `flake.nix`) leaves a stale lock entry and `nix build` refuses to build.

## Fix

- New `local_path_input_names(packages_dir)` in `flake::template`: collects the flake input names backed by `path:` URLs — local flake dirs (`packages/<name>/flake.nix`) and local `.nix` packages whose declared input URL starts with `path:`.
- `nixy sync`: before building, if `flake.lock` exists and there are local path inputs, runs `nix flake update <inputs>` to re-lock them. Failure is a warning only; the build surfaces the real error.
- `nixy profile <name>` (switch): same refresh before its direct `Nix::build`. `install`/`uninstall` already go through `sync::run`, so they're covered.
- Bumps version to 0.4.3.

## Testing

- New unit test `test_local_path_input_names` (flake dir included, `path:` .nix input included, `github:` input excluded).
- `cargo test`: 72 passed. `cargo clippy` / `cargo fmt --check`: clean.