### PR TITLE
Fix uninstall of auto-discovered local packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "nixy-rs"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nixy-rs"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.80"
 description = "Homebrew-style wrapper for Nix using flake.nix"

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -117,20 +117,13 @@ fn uninstall_with_nixy_config(config: &Config, package: &str) -> Result<()> {
 
     info(&format!("Uninstalling {}...", package));
 
-    // Note: We do NOT delete global package definitions from packages/ directory.
-    // The packages/ directory is shared across all profiles in the new format,
-    // so uninstalling from one profile must not delete the global package definition.
-    // Global cleanup, if desired, should be handled manually or by a dedicated command.
+    // Check for a local package definition in the shared packages/ directory.
+    // Local packages are auto-discovered into every profile's flake, so they may
+    // not appear in any profile's package list at all.
     let global_pkg_file = config.global_packages_dir.join(format!("{}.nix", package));
     let global_flake_dir = config.global_packages_dir.join(package);
-
-    if global_pkg_file.exists()
-        || (global_flake_dir.exists() && global_flake_dir.join("flake.nix").exists())
-    {
-        warn(
-            "Note: Local package definition in packages/ was not removed (shared across profiles)",
-        );
-    }
+    let local_def_exists = global_pkg_file.exists()
+        || (global_flake_dir.exists() && global_flake_dir.join("flake.nix").exists());
 
     // Remove package from profile
     let profile = nixy_config
@@ -138,7 +131,34 @@ fn uninstall_with_nixy_config(config: &Config, package: &str) -> Result<()> {
         .ok_or_else(|| Error::ProfileNotFound(active_profile.clone()))?;
     let removed_from_config = profile.remove_package(package);
 
-    if !removed_from_config {
+    if removed_from_config {
+        // Package was listed in the profile. We do NOT delete the global package
+        // definition from packages/ because it is shared across all profiles.
+        if local_def_exists {
+            warn(
+                "Note: Local package definition in packages/ was not removed (shared across profiles)",
+            );
+        }
+    } else if local_def_exists {
+        // Package exists only as an auto-discovered local definition. The only way
+        // to remove it is to delete the definition itself.
+        warn("Removing local package definition from packages/ (shared across profiles)");
+        if global_pkg_file.exists() {
+            info(&format!(
+                "Removing local package definition: {}",
+                global_pkg_file.display()
+            ));
+            fs::remove_file(&global_pkg_file)?;
+            git_rm(&config.global_packages_dir, &format!("{}.nix", package));
+        } else {
+            info(&format!(
+                "Removing local flake: {}",
+                global_flake_dir.display()
+            ));
+            fs::remove_dir_all(&global_flake_dir)?;
+            git_rm_recursive(&config.global_packages_dir, package);
+        }
+    } else {
         return Err(Error::PackageNotFound(package.to_string()));
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1846,3 +1846,108 @@ fn test_file_help() {
         stdout
     );
 }
+
+// =============================================================================
+// Uninstall local package (auto-discovered, not in profile) tests
+// =============================================================================
+
+#[test]
+fn test_uninstall_local_only_package_removes_definition() {
+    let env = TestEnv::new();
+
+    // New nixy.json format with an empty profile (package not listed)
+    let nixy_json_content = r#"{
+  "version": 3,
+  "active_profile": "default",
+  "profiles": {
+    "default": {
+      "packages": [],
+      "resolved_packages": [],
+      "custom_packages": []
+    }
+  }
+}"#;
+    std::fs::create_dir_all(&env.config_dir).unwrap();
+    std::fs::write(env.config_dir.join("nixy.json"), nixy_json_content).unwrap();
+
+    // Create an auto-discovered local flake package in packages/
+    let local_flake_dir = env.config_dir.join("packages/my-local-flake");
+    std::fs::create_dir_all(&local_flake_dir).unwrap();
+    let flake_content = r#"{
+  description = "local flake package";
+  outputs = { self }: {
+    packages = { };
+  };
+}"#;
+    std::fs::write(local_flake_dir.join("flake.nix"), flake_content).unwrap();
+
+    let output = env
+        .cmd()
+        .args(["uninstall", "my-local-flake"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Must not fail with "package not found" - the local definition exists
+    assert!(
+        !stderr.contains("not found in nixpkgs"),
+        "Should not report package as not found: stderr={}",
+        stderr
+    );
+
+    // The local package definition must be removed
+    assert!(
+        !local_flake_dir.exists(),
+        "Local flake definition should be removed"
+    );
+}
+
+#[test]
+fn test_uninstall_local_only_nix_file_removes_definition() {
+    let env = TestEnv::new();
+
+    let nixy_json_content = r#"{
+  "version": 3,
+  "active_profile": "default",
+  "profiles": {
+    "default": {
+      "packages": [],
+      "resolved_packages": [],
+      "custom_packages": []
+    }
+  }
+}"#;
+    std::fs::create_dir_all(&env.config_dir).unwrap();
+    std::fs::write(env.config_dir.join("nixy.json"), nixy_json_content).unwrap();
+
+    // Create an auto-discovered local .nix package in packages/
+    let packages_dir = env.config_dir.join("packages");
+    std::fs::create_dir_all(&packages_dir).unwrap();
+    let local_pkg_content = r#"{ lib, stdenv }:
+stdenv.mkDerivation {
+  pname = "my-local-pkg";
+  version = "1.0.0";
+  src = ./.;
+}"#;
+    let local_pkg_file = packages_dir.join("my-local-pkg.nix");
+    std::fs::write(&local_pkg_file, local_pkg_content).unwrap();
+
+    let output = env
+        .cmd()
+        .args(["uninstall", "my-local-pkg"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stderr.contains("not found in nixpkgs"),
+        "Should not report package as not found: stderr={}",
+        stderr
+    );
+    assert!(
+        !local_pkg_file.exists(),
+        "Local package definition should be removed"
+    );
+}


### PR DESCRIPTION
## Summary
- `nixy remove <pkg>` failed with `Package '<pkg>' not found in nixpkgs or is not a valid derivation` for local packages in `packages/` that are auto-discovered but not listed in any profile's package list (e.g. `hunk`)
- Now, when the package is not in the profile but a local definition exists (either `packages/<pkg>.nix` or `packages/<pkg>/flake.nix`), the local definition is removed (with a warning that it is shared across profiles), then the flake is regenerated and synced
- When the package IS in the profile list, behavior is unchanged: it is removed from the profile only and the shared definition is preserved

## Test plan
- [x] `cargo test` (74 passed)
- [x] New integration tests: `test_uninstall_local_only_package_removes_definition`, `test_uninstall_local_only_nix_file_removes_definition`
